### PR TITLE
Moved all framework references in docker build files to master instead of v4.0

### DIFF
--- a/docker/compose-techempower-tests/ffead-cpp/install_ffead-cpp-framework-forsql.sh
+++ b/docker/compose-techempower-tests/ffead-cpp/install_ffead-cpp-framework-forsql.sh
@@ -19,9 +19,10 @@ rm -rf libcuckoo-master
 
 cd $IROOT
 
-wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-unzip v4.0.zip
-mv ffead-cpp-4.0 ffead-cpp-src
+wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+unzip master.zip
+rm -f master.zip
+mv ffead-cpp-master ffead-cpp-src
 mv ${TROOT}/ffead-cpp-src ffead-cpp-src
 cd ffead-cpp-src/
 

--- a/docker/compose-techempower-tests/ffead-cpp/install_ffead-cpp-framework.sh
+++ b/docker/compose-techempower-tests/ffead-cpp/install_ffead-cpp-framework.sh
@@ -20,9 +20,10 @@ rm -rf libcuckoo-master
 cd $IROOT
 
 
-wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-unzip v4.0.zip
-mv ffead-cpp-4.0 ffead-cpp-src
+wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+unzip master.zip
+rm -f master.zip
+mv ffead-cpp-master ffead-cpp-src
 mv ${TROOT}/ffead-cpp-src ffead-cpp-src
 cd ffead-cpp-src/
 

--- a/docker/os-based/DockerFile-ArchLinux-mingw64-ffead-cpp-4
+++ b/docker/os-based/DockerFile-ArchLinux-mingw64-ffead-cpp-4
@@ -40,10 +40,10 @@ RUN wget -q https://github.com/efficient/libcuckoo/archive/master.zip
 RUN unzip master.zip
 RUN rm -f master.zip
 
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 
 WORKDIR /tmp/libcuckoo-master
 RUN x86_64-w64-mingw32-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ .

--- a/docker/os-based/DockerFile-ArchLinux-x64-ffead-cpp-4.0
+++ b/docker/os-based/DockerFile-ArchLinux-x64-ffead-cpp-4.0
@@ -15,10 +15,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 RUN cmake -DSRV_EMB=on -DMOD_REDIS=on -DMOD_SDORM_MONGO=on .
 RUN make install -j4

--- a/docker/os-based/DockerFile-ArchLinux-x64-ffead-cpp-4.0_autoconf
+++ b/docker/os-based/DockerFile-ArchLinux-x64-ffead-cpp-4.0_autoconf
@@ -15,10 +15,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 RUN chmod +x autogen.sh
 RUN ./autogen.sh

--- a/docker/os-based/DockerFile-Centos7-x64-ffead-cpp-4.0
+++ b/docker/os-based/DockerFile-Centos7-x64-ffead-cpp-4.0
@@ -31,10 +31,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 RUN cmake -DSRV_EMB=on -DMOD_REDIS=on -DMOD_SDORM_MONGO=on .
 RUN make install -j4

--- a/docker/os-based/DockerFile-Centos7-x64-ffead-cpp-4.0_autoconf
+++ b/docker/os-based/DockerFile-Centos7-x64-ffead-cpp-4.0_autoconf
@@ -31,10 +31,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 RUN chmod +x autogen.sh
 RUN ./autogen.sh

--- a/docker/os-based/DockerFile-Gentoo-x64-ffead-cpp-4.0
+++ b/docker/os-based/DockerFile-Gentoo-x64-ffead-cpp-4.0
@@ -28,10 +28,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 RUN cmake -DSRV_EMB=on -DMOD_REDIS=on -DMOD_SDORM_MONGO=on .
 RUN make install -j4

--- a/docker/os-based/DockerFile-Gentoo-x64-ffead-cpp-4.0_autoconf
+++ b/docker/os-based/DockerFile-Gentoo-x64-ffead-cpp-4.0_autoconf
@@ -26,10 +26,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 RUN chmod +x autogen.sh
 RUN ./autogen.sh

--- a/docker/os-based/DockerFile-OpenSuseTumbleweed-x64-ffead-cpp-4.0
+++ b/docker/os-based/DockerFile-OpenSuseTumbleweed-x64-ffead-cpp-4.0
@@ -25,10 +25,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 RUN cmake -DSRV_EMB=on -DMOD_REDIS=on -DMOD_SDORM_MONGO=on .
 RUN make install -j4

--- a/docker/os-based/DockerFile-OpenSuseTumbleweed-x64-ffead-cpp-4.0_autoconf
+++ b/docker/os-based/DockerFile-OpenSuseTumbleweed-x64-ffead-cpp-4.0_autoconf
@@ -25,10 +25,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 RUN chmod +x autogen.sh
 RUN ./autogen.sh

--- a/docker/os-based/DockerFile-UbuntuBionic-x64-ffead-cpp-4.0
+++ b/docker/os-based/DockerFile-UbuntuBionic-x64-ffead-cpp-4.0
@@ -15,10 +15,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 RUN cmake -DSRV_EMB=on -DMOD_REDIS=on -DMOD_SDORM_MONGO=on .
 RUN make install -j4

--- a/docker/os-based/DockerFile-UbuntuBionic-x64-ffead-cpp-4.0_autoconf
+++ b/docker/os-based/DockerFile-UbuntuBionic-x64-ffead-cpp-4.0_autoconf
@@ -15,10 +15,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 RUN chmod +x autogen.sh
 RUN ./autogen.sh

--- a/docker/techempower-config/install_ffead-cpp-framework.sh
+++ b/docker/techempower-config/install_ffead-cpp-framework.sh
@@ -8,10 +8,10 @@ SERV_THREADS=$(( $MAX_THREADS - $WRIT_THREADS ))
 
 cd $IROOT
 
-wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-unzip v4.0.zip
-rm -f v4.0.zip
-mv ffead-cpp-4.0 ffead-cpp-src
+wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+unzip master.zip
+rm -f master.zip
+mv ffead-cpp-master ffead-cpp-src
 mv ffead-cpp-src/lang-server-backends ${IROOT}/
 cd $IROOT
 

--- a/docker/webrtc-peerjs/DockerFile-UbuntuBionic-x64-ffead-cpp-4.0
+++ b/docker/webrtc-peerjs/DockerFile-UbuntuBionic-x64-ffead-cpp-4.0
@@ -15,10 +15,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 
 RUN rm -rf web/default web/oauthApp web/flexApp web/markers web/te-benchmark web/te-benchmark-um

--- a/docker/webrtc-peerjs/DockerFile-UbuntuBionic-x64-ffead-cpp-4.0_autoconf
+++ b/docker/webrtc-peerjs/DockerFile-UbuntuBionic-x64-ffead-cpp-4.0_autoconf
@@ -15,10 +15,10 @@ RUN rm -rf /tmp/libcuckoo-master
 
 #Install ffead-cpp
 WORKDIR /tmp
-RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/v4.0.zip
-RUN unzip v4.0.zip
-RUN mv ffead-cpp-4.0 ffead-cpp-src
-RUN rm -f v4.0.zip
+RUN wget -q https://github.com/sumeetchhetri/ffead-cpp/archive/master.zip
+RUN unzip master.zip
+RUN mv ffead-cpp-master ffead-cpp-src
+RUN rm -f master.zip
 WORKDIR /tmp/ffead-cpp-src
 
 RUN rm -rf web/default web/oauthApp web/flexApp web/markers web/te-benchmark web/te-benchmark-um

--- a/src/framework/ConfigurationHandler.cpp
+++ b/src/framework/ConfigurationHandler.cpp
@@ -2569,6 +2569,8 @@ void ConfigurationHandler::handleRestControllerMarker(ClassStructure& cs, const 
 
 void ConfigurationHandler::initializeDataSources()
 {
+	bool isSinglEVH = StringUtil::toLowerCopy(ConfigurationData::getInstance()->coreServerProperties.sprops["EVH_SINGLE"])=="true";
+	DataSourceManager::init(isSinglEVH);
 	Logger logger = LoggerFactory::getLogger("ConfigurationHandler");
 	std::map<std::string, bool, std::less<> > mycntxts = ConfigurationData::getInstance()->servingContexts;
 	std::map<std::string, std::map<std::string, ConnectionProperties, std::less<> >, std::less<> > sdormConnProperties = ConfigurationData::getInstance()->sdormConnProperties;
@@ -2591,6 +2593,8 @@ void ConfigurationHandler::initializeDataSources()
 
 void ConfigurationHandler::initializeCaches()
 {
+	bool isSinglEVH = StringUtil::toLowerCopy(ConfigurationData::getInstance()->coreServerProperties.sprops["EVH_SINGLE"])=="true";
+	CacheManager::init(isSinglEVH);
 	std::map<std::string, bool, std::less<> > mycntxts = ConfigurationData::getInstance()->servingContexts;
 	std::map<std::string, std::map<std::string, ConnectionProperties, std::less<> >, std::less<> > cacheConnProperties = ConfigurationData::getInstance()->cacheConnProperties;
 	std::map<std::string, bool, std::less<> >::iterator mit;

--- a/src/modules/cache/CacheManager.h
+++ b/src/modules/cache/CacheManager.h
@@ -32,6 +32,8 @@
 #include "GenericObject.h"
 
 class CacheManager {
+	static bool isSinglEVH;
+	static std::map<std::string, CacheInterface*> sevhCchImpls;
 	Logger logger;
 	static std::map<std::string, CacheManager*> caches;
 	static std::map<std::string, std::string> defDsnNames;
@@ -43,9 +45,11 @@ class CacheManager {
 	CacheManager(const ConnectionProperties& props);
 	friend class ConfigurationHandler;
 public:
+	static void init(bool isSinglEVH);
 	CacheManager();
 	virtual ~CacheManager();
 	static CacheInterface* getImpl(std::string name = "", std::string appName = "");
+	static void cleanImpl(CacheInterface*);
 };
 
 #endif /* CACHEMANAGER_H_ */

--- a/src/modules/sdorm/DataSourceManager.h
+++ b/src/modules/sdorm/DataSourceManager.h
@@ -36,6 +36,8 @@
 class DataSourceManager;
 
 class DataSourceManager {
+	static bool isSinglEVH;
+	static std::map<std::string, DataSourceInterface*> sevhDsnImpls;
 	Logger logger;
 	static std::map<std::string, DataSourceManager*> dsns;
 	static std::map<std::string, std::string> defDsnNames;
@@ -47,8 +49,10 @@ class DataSourceManager {
 	static void destroy();
 	friend class ConfigurationHandler;
 public:
+	static void init(bool isSinglEVH);
 	virtual ~DataSourceManager();
 	static DataSourceInterface* getImpl(std::string name = "", std::string appName = "");
+	static void cleanImpl(DataSourceInterface*);
 };
 
 #endif /* DATASOURCEMANAGER_H_ */

--- a/web/default/src/DefaultController.cpp
+++ b/web/default/src/DefaultController.cpp
@@ -46,7 +46,7 @@ bool DefaultController::service(HttpRequest* req, HttpResponse* res)
 	std::cout << "\n Sdorm Query fetched " << tec1.size() << " rows\n" << std::flush;
 	std::vector<Test4> tec2 = sqli->getAll<Test4>();
 	std::cout << "\n Sprint Query fetched " << tec2.size() << " rows\n" << std::flush;
-	delete sqli;
+	DataSourceManager::cleanImpl(sqli);
 	return true;
 }
 

--- a/web/peer-server/src/PeerServerController.cpp
+++ b/web/peer-server/src/PeerServerController.cpp
@@ -136,9 +136,9 @@ bool PeerServerController::onOpen(WebSocketData* wreq, WebSocketRespponseData* w
 	CacheInterface* cchi = CacheManager::getImpl();
 	try {
 		cchi->set(id, nodeIdentifier);
-		delete cchi;
+		CacheManager::cleanImpl(cchi);
 	} catch (const std::exception& e) {
-		delete cchi;
+		CacheManager::cleanImpl(cchi);
 	}
 
 	PeerState* st = new PeerState(id, token, getSif());
@@ -158,9 +158,9 @@ void PeerServerController::onClose(std::string uniqueAddress) {
 		CacheInterface* cchi = CacheManager::getImpl();
 		try {
 			cchi->remove(st->id);
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		} catch (const std::exception& e) {
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		}
 		delete st;
 		clients.erase(uniqueAddress);
@@ -199,12 +199,12 @@ bool PeerServerController::onMessage(WebSocketData *req, WebSocketRespponseData 
 			msgNodeIdentifier = cchi->getValue(id);
 			//std::cout << "WS:Req:Token " << etoken << std::endl;
 			if(msgNodeIdentifier=="") {
-				delete cchi;
+				CacheManager::cleanImpl(cchi);
 				return false;
 			}
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		} catch (const std::exception& e) {
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		}
 
 		//std::cout << "WS:Req:Id " << id << std::endl;
@@ -234,9 +234,9 @@ bool PeerServerController::onMessage(WebSocketData *req, WebSocketRespponseData 
 				try {
 					cchi->addToQ(msgNodeIdentifier, dstId+"|"+JSONUtil::getDocumentStr(el));
 					std::cout << "WS:Queuing: " << type << ":For:" << dstId << " " << uniqueAddress << " " << st->id << " " << st->token << std::endl;
-					delete cchi;
+					CacheManager::cleanImpl(cchi);
 				} catch (const std::exception& e) {
-					delete cchi;
+					CacheManager::cleanImpl(cchi);
 				}
 			}
 		}
@@ -269,9 +269,9 @@ void* PeerServerController::handle(void *inp) {
 				}
 			}
 			std::cout << "WS:PeerHandler:Process:End" << std::endl;
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		} catch (const std::exception& e) {
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		}
 		Thread::sSleep(1);
 	}
@@ -341,10 +341,10 @@ bool PeerServerRouter::isValidUser(const std::string &id, const std::string &tok
 			res->setHTTPResponseStatus(HTTPResponseStatus::Unauthorized);
 			return false;
 		}
-		delete cchi;
+		CacheManager::cleanImpl(cchi);
 		return true;
 	} catch (const std::exception& e) {
-		delete cchi;
+		CacheManager::cleanImpl(cchi);
 		return false;
 	}
 }
@@ -387,9 +387,9 @@ void PeerServerRouter::route(HttpRequest* req, HttpResponse* res, void* dlib, vo
 		CacheInterface* cchi = CacheManager::getImpl();
 		try {
 			cchi->addToQ(dstId+"_q", JSONUtil::getDocumentStr(el));
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		} catch (const std::exception& e) {
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		}
 		res->setHTTPResponseStatus(HTTPResponseStatus::Ok);
 	} else if(StringUtil::endsWith(path, "/candidate")) {
@@ -418,9 +418,9 @@ void PeerServerRouter::route(HttpRequest* req, HttpResponse* res, void* dlib, vo
 		CacheInterface* cchi = CacheManager::getImpl();
 		try {
 			cchi->addToQ(dstId+"_q", JSONUtil::getDocumentStr(el));
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		} catch (const std::exception& e) {
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		}
 		res->setHTTPResponseStatus(HTTPResponseStatus::Ok);
 	} else if(StringUtil::endsWith(path, "/answer")) {
@@ -449,9 +449,9 @@ void PeerServerRouter::route(HttpRequest* req, HttpResponse* res, void* dlib, vo
 		CacheInterface* cchi = CacheManager::getImpl();
 		try {
 			cchi->addToQ(dstId+"_q", JSONUtil::getDocumentStr(el));
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		} catch (const std::exception& e) {
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		}
 		res->setHTTPResponseStatus(HTTPResponseStatus::Ok);
 	} else if(StringUtil::endsWith(path, "/leave")) {
@@ -465,9 +465,9 @@ void PeerServerRouter::route(HttpRequest* req, HttpResponse* res, void* dlib, vo
 		try {
 			cchi->remove(id);
 			cchi->remove(id+"_q");
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		} catch (const std::exception& e) {
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		}
 		res->addHeaderValue(HttpResponse::Connection, "close");
 		res->setHTTPResponseStatus(HTTPResponseStatus::Ok);
@@ -489,9 +489,9 @@ void PeerServerRouter::route(HttpRequest* req, HttpResponse* res, void* dlib, vo
 			if(rsc.at(rsc.length()-1)==',') {
 				rsc = rsc.substr(0, rsc.length()-1);
 			}
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		} catch (const std::exception& e) {
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		}
 		rsc += "]";
 		res->setContent(rsc);
@@ -553,9 +553,9 @@ void PeerServerRouter::route(HttpRequest* req, HttpResponse* res, void* dlib, vo
 		CacheInterface* cchi = CacheManager::getImpl();
 		try {
 			cchi->set(id, token);
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		} catch (const std::exception& e) {
-			delete cchi;
+			CacheManager::cleanImpl(cchi);
 		}
 
 		JSONElement er = JSONElement::object();

--- a/web/te-benchmark-um/src/TeBkUm.cpp
+++ b/web/te-benchmark-um/src/TeBkUm.cpp
@@ -69,9 +69,9 @@ void TeBkUmRouter::db(TeBkUmWorld& w) {
 	id << rid;
 	try {
 		w = sqli->get<TeBkUmWorld>(id);
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 	} catch(const std::exception& e) {
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 		throw e;
 	}
 }
@@ -94,9 +94,9 @@ void TeBkUmRouter::queries(const char* q, int ql, std::vector<TeBkUmWorld>& wlst
 			wlst.push_back(w);
 		}
 		sqli->endSession();
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 	} catch(const std::exception& e) {
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 		throw e;
 	}
 }
@@ -132,9 +132,9 @@ void TeBkUmRouter::updates(const char* q, int ql, std::vector<TeBkUmWorld>& wlst
 		sqli->commit();
 
 		sqli->endSession();
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 	} catch(const std::exception& e) {
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 		throw e;
 	}
 }
@@ -151,11 +151,11 @@ void TeBkUmRouter::updateCache() {
 			TeBkUmWorld& w = wlist.at(c);
 			cchi->setO(CastUtil::fromNumber(w.getId()), w);
 		}
-		delete sqli;
-		delete cchi;
+		DataSourceManager::cleanImpl(sqli);
+		CacheManager::cleanImpl(cchi);
 	} catch(const std::exception& e) {
-		delete sqli;
-		delete cchi;
+		DataSourceManager::cleanImpl(sqli);
+		CacheManager::cleanImpl(cchi);
 		throw e;
 	}
 }
@@ -176,9 +176,9 @@ void TeBkUmRouter::cachedWorlds(const char* q, int ql, std::vector<TeBkUmWorld>&
 		}
 
 		wlst = cchi->mgetO<TeBkUmWorld>(keys);
-		delete cchi;
+		CacheManager::cleanImpl(cchi);
 	} catch(const std::exception& e) {
-		delete cchi;
+		CacheManager::cleanImpl(cchi);
 		throw e;
 	}
 }
@@ -200,12 +200,12 @@ void TeBkUmRouter::getContext(HttpRequest* request, Context* context) {
 		nf.setMessage("Additional fortune added at request time.");
 		flst.push_back(nf);
 		std::sort (flst.begin(), flst.end());
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 
 		context->insert(std::pair<std::string, GenericObject>("fortunes", GenericObject()));
 		context->find("fortunes")->second << flst;
 	} catch(...) {
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 		throw;
 	}
 }

--- a/web/te-benchmark/src/TeBkFortuneTemplate.cpp
+++ b/web/te-benchmark/src/TeBkFortuneTemplate.cpp
@@ -43,7 +43,7 @@ void TeBkFortuneTemplate::getContext(HttpRequest* request, Context* context)
 		nf.setMessage("Additional fortune added at request time.");
 		flst.push_back(nf);
 		std::sort (flst.begin(), flst.end());
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 
 		context->insert(std::pair<std::string, GenericObject>("fortunes", GenericObject()));
 		context->find("fortunes")->second << flst;

--- a/web/te-benchmark/src/TeBkRestController.cpp
+++ b/web/te-benchmark/src/TeBkRestController.cpp
@@ -44,10 +44,10 @@ TeBkWorld TeBkRestController::db() {
 	id << rid;
 	try {
 		TeBkWorld w = sqli->get<TeBkWorld>(id);
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 		return w;
 	} catch(const std::exception& e) {
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 		throw e;
 	}
 }
@@ -74,10 +74,10 @@ std::vector<TeBkWorld> TeBkRestController::queries(std::string queries) {
 			wlst.push_back(w);
 		}
 		sqli->endSession();
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 		return wlst;
 	} catch(const std::exception& e) {
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 		throw e;
 	}
 }
@@ -117,10 +117,10 @@ std::vector<TeBkWorld> TeBkRestController::updates(std::string queries) {
 		sqli->commit();
 
 		sqli->endSession();
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 		return wlst;
 	} catch(const std::exception& e) {
-		delete sqli;
+		DataSourceManager::cleanImpl(sqli);
 		throw e;
 	}
 }
@@ -145,11 +145,11 @@ void TeBkRestController::updateCache() {
 			TeBkWorld& w = wlist.at(c);
 			cchi->setO(CastUtil::fromNumber(w.getId()), w);
 		}
-		delete sqli;
-		delete cchi;
+		DataSourceManager::cleanImpl(sqli);
+		CacheManager::cleanImpl(cchi);
 	} catch(const std::exception& e) {
-		delete sqli;
-		delete cchi;
+		DataSourceManager::cleanImpl(sqli);
+		CacheManager::cleanImpl(cchi);
 		throw e;
 	}
 }
@@ -174,10 +174,10 @@ std::vector<TeBkWorld> TeBkRestController::cachedWorlds(std::string count) {
 
 		std::vector<TeBkWorld> wlst = cchi->mgetO<TeBkWorld>(keys);
 
-		delete cchi;
+		CacheManager::cleanImpl(cchi);
 		return wlst;
 	} catch(const std::exception& e) {
-		delete cchi;
+		CacheManager::cleanImpl(cchi);
 		throw e;
 	}
 }


### PR DESCRIPTION
When in single event handler mode (a.k.a process mode) use the same db/cache impl instance across calls